### PR TITLE
Fix of type mis-match error in make_log_bucket_position function of modeling_tf_deberta_v2.py

### DIFF
--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -548,9 +548,9 @@ def make_log_bucket_position(relative_pos, bucket_size, max_position):
     abs_pos = tf.where((relative_pos < mid) & (relative_pos > -mid), mid - 1, tf.math.abs(relative_pos))
     log_pos = (
         tf.math.ceil(
-            tf.cast(tf.math.log(abs_pos / mid), tf.float32) / tf.math.log((max_position - 1) / mid) * (mid - 1)
+            tf.cast(tf.math.log(abs_pos / mid), tf.float32) / tf.cast(tf.math.log((max_position - 1) / mid), tf.float32) * tf.cast(mid - 1, tf.float32)  # in graph mode
         )
-        + mid
+        + tf.cast(mid, tf.float32)
     )
     bucket_pos = tf.cast(
         tf.where(abs_pos <= mid, tf.cast(relative_pos, tf.float32), log_pos * tf.cast(sign, tf.float32)), tf.int32


### PR DESCRIPTION
Fix of type mis-match error in make_log_bucket_position

# What does this PR do?

This PR fixes the type mismatch error in the function of make_log_bucket_position in modeling_tf_deberta_v2.py

In the function, `log_pos` is type of float32 and computed with the following code:
```
    log_pos = (
        tf.math.ceil(
            tf.cast(tf.math.log(abs_pos / mid), tf.float32) / tf.math.log((max_position - 1) / mid) * (mid - 1)
        )
        + mid
```
In the tf.math.ceil(), the second `tf.math.log()` gives type of float64 and the third term `(mid-1)` gives type of int32. These terms cause type mismatch error when dividing or multiplying with the first term with type of float32. And the final 'add' term `mid` is also type of int32 and causes type mismatch error. So, all these terms should be casted to float32.

This PR fixes the issue [#31988](https://github.com/huggingface/transformers/issues/31988)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [V] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [V] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker

