### PR TITLE
TF DeBERTa Models supporting mixed precision

### DIFF
--- a/src/transformers/models/deberta/modeling_tf_deberta.py
+++ b/src/transformers/models/deberta/modeling_tf_deberta.py
@@ -101,8 +101,8 @@ class TFDebertaXSoftmax(keras.layers.Layer):
 
     def call(self, inputs: tf.Tensor, mask: tf.Tensor):
         rmask = tf.logical_not(tf.cast(mask, tf.bool))
-        output = tf.where(rmask, float("-inf"), inputs)
-        output = stable_softmax(output, self.axis)
+        output = tf.where(rmask, tf.cast(float("-inf"), dtype=self.compute_dtype), inputs)  # mixed precision # float("-inf")
+        output = stable_softmax(tf.cast(output, dtype=tf.float32), self.axis)  # mixed precision # output
         output = tf.where(rmask, 0.0, output)
         return output
 
@@ -129,13 +129,14 @@ class TFDebertaStableDropout(keras.layers.Layer):
             - tf.compat.v1.distributions.Bernoulli(probs=1.0 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
             tf.bool,
         )
-        scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)
+        scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=self.compute_dtype)  # mixed precision # dtype=tf.float32)
+
         if self.drop_prob > 0:
-            inputs = tf.where(mask, 0.0, inputs) * scale
+            inputs = tf.where(mask, tf.cast(0.0, dtype=self.compute_dtype), inputs) * scale  # mixed precision # 0.0
 
         def grad(upstream):
             if self.drop_prob > 0:
-                return tf.where(mask, 0.0, upstream) * scale
+                return tf.where(mask, tf.cast(0.0, dtype=self.compute_dtype), upstream) * scale  # mixed precision # 0.0
             else:
                 return upstream
 
@@ -701,9 +702,9 @@ class TFDebertaDisentangledSelfAttention(keras.layers.Layer):
             ws = tf.split(
                 tf.transpose(self.in_proj.weight[0]), num_or_size_splits=self.num_attention_heads * 3, axis=0
             )
-            qkvw = tf.TensorArray(dtype=tf.float32, size=3)
+            qkvw = tf.TensorArray(dtype=self.dtype, size=3)  # mixed precision # tf.float32
             for k in tf.range(3):
-                qkvw_inside = tf.TensorArray(dtype=tf.float32, size=self.num_attention_heads)
+                qkvw_inside = tf.TensorArray(dtype=self.dtype, size=self.num_attention_heads)  # mixed precision # tf.float32
                 for i in tf.range(self.num_attention_heads):
                     qkvw_inside = qkvw_inside.write(i, ws[i * 3 + k])
                 qkvw = qkvw.write(k, qkvw_inside.concat())
@@ -796,6 +797,7 @@ class TFDebertaDisentangledSelfAttention(keras.layers.Layer):
             pos_query_layer = self.pos_q_proj(rel_embeddings)
             pos_query_layer = self.transpose_for_scores(pos_query_layer)
             pos_query_layer /= tf.math.sqrt(tf.cast(shape_list(pos_query_layer)[-1] * scale_factor, dtype=tf.float32))
+            pos_query_layer /= tf.math.sqrt(tf.cast(shape_list(pos_query_layer)[-1] * scale_factor, dtype=self.compute_dtype))  # mixed precision # tf.float32
             if shape_list(query_layer)[-2] != shape_list(key_layer)[-2]:
                 r_pos = build_relative_position(shape_list(key_layer)[-2], shape_list(key_layer)[-2])
             else:
@@ -923,7 +925,7 @@ class TFDebertaEmbeddings(keras.layers.Layer):
             if len(shape_list(mask)) != len(shape_list(final_embeddings)):
                 if len(shape_list(mask)) == 4:
                     mask = tf.squeeze(tf.squeeze(mask, axis=1), axis=1)
-                mask = tf.cast(tf.expand_dims(mask, axis=2), tf.float32)
+                mask = tf.cast(tf.expand_dims(mask, axis=2), dtype=self.compute_dtype)
 
             final_embeddings = final_embeddings * mask
 

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -103,8 +103,8 @@ class TFDebertaV2XSoftmax(keras.layers.Layer):
 
     def call(self, inputs: tf.Tensor, mask: tf.Tensor):
         rmask = tf.logical_not(tf.cast(mask, tf.bool))
-        output = tf.where(rmask, float("-inf"), inputs)
-        output = stable_softmax(output, self.axis)
+        output = tf.where(rmask, tf.cast(float("-inf"), dtype=self.compute_dtype), inputs)  # mixed precision # float("-inf")
+        output = stable_softmax(tf.cast(output, dtype=tf.float32), self.axis)  # mixed precision # output
         output = tf.where(rmask, 0.0, output)
         return output
 
@@ -132,13 +132,13 @@ class TFDebertaV2StableDropout(keras.layers.Layer):
             - tf.compat.v1.distributions.Bernoulli(probs=1.0 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
             tf.bool,
         )
-        scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)
+        scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=self.compute_dtype)  # mixed precision # dtype=tf.float32)
         if self.drop_prob > 0:
-            inputs = tf.where(mask, 0.0, inputs) * scale
+            inputs = tf.where(mask, tf.cast(0.0, dtype=self.compute_dtype), inputs) * scale  # mixed precision # 0.0
 
         def grad(upstream):
             if self.drop_prob > 0:
-                return tf.where(mask, 0.0, upstream) * scale
+                return tf.where(mask, tf.cast(0.0, dtype=self.compute_dtype), upstream) * scale  # mixed precision # 0.0
             else:
                 return upstream
 
@@ -401,7 +401,7 @@ class TFDebertaV2ConvLayer(keras.layers.Layer):
             if len(shape_list(input_mask)) != len(shape_list(layer_norm_input)):
                 if len(shape_list(input_mask)) == 4:
                     input_mask = tf.squeeze(tf.squeeze(input_mask, axis=1), axis=1)
-                input_mask = tf.cast(tf.expand_dims(input_mask, axis=2), tf.float32)
+                input_mask = tf.cast(tf.expand_dims(input_mask, axis=2), dtype=self.compute_dtype)  # mixed precision # tf.float32)
 
             output_states = output * input_mask
 
@@ -767,7 +767,7 @@ class TFDebertaV2DisentangledSelfAttention(keras.layers.Layer):
             scale_factor += 1
         if "p2c" in self.pos_att_type:
             scale_factor += 1
-        scale = tf.math.sqrt(tf.cast(shape_list(query_layer)[-1] * scale_factor, tf.float32))
+        scale = tf.math.sqrt(tf.cast(shape_list(query_layer)[-1] * scale_factor, dtype=self.compute_dtype))  # mixed precision # tf.float32))
         attention_scores = tf.matmul(query_layer, tf.transpose(key_layer, [0, 2, 1]) / scale)
         if self.relative_attention:
             rel_embeddings = self.pos_dropout(rel_embeddings)
@@ -850,7 +850,7 @@ class TFDebertaV2DisentangledSelfAttention(keras.layers.Layer):
         score = 0
         # content->position
         if "c2p" in self.pos_att_type:
-            scale = tf.math.sqrt(tf.cast(shape_list(pos_key_layer)[-1] * scale_factor, tf.float32))
+            scale = tf.math.sqrt(tf.cast(shape_list(pos_key_layer)[-1] * scale_factor, dtype=self.compute_dtype))  # mixed precision # tf.float32))
             c2p_att = tf.matmul(query_layer, tf.transpose(pos_key_layer, [0, 2, 1]))
             c2p_pos = tf.clip_by_value(relative_pos + att_span, 0, att_span * 2 - 1)
             c2p_att = take_along_axis(
@@ -864,7 +864,7 @@ class TFDebertaV2DisentangledSelfAttention(keras.layers.Layer):
 
         # position->content
         if "p2c" in self.pos_att_type:
-            scale = tf.math.sqrt(tf.cast(shape_list(pos_query_layer)[-1] * scale_factor, tf.float32))
+            scale = tf.math.sqrt(tf.cast(shape_list(pos_query_layer)[-1] * scale_factor, dtype=self.compute_dtype))  # mixed precision # tf.float32))
             if shape_list(key_layer)[-2] != shape_list(query_layer)[-2]:
                 r_pos = build_relative_position(
                     shape_list(key_layer)[-2],
@@ -1031,7 +1031,7 @@ class TFDebertaV2Embeddings(keras.layers.Layer):
             if len(shape_list(mask)) != len(shape_list(final_embeddings)):
                 if len(shape_list(mask)) == 4:
                     mask = tf.squeeze(tf.squeeze(mask, axis=1), axis=1)
-                mask = tf.cast(tf.expand_dims(mask, axis=2), tf.float32)
+                mask = tf.cast(tf.expand_dims(mask, axis=2), dtype=self.compute_dtype)  # mixed precision # tf.float32)
 
             final_embeddings = final_embeddings * mask
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes some codes of TF DeBERTa (version 1 and 2) that do not support Mixed Precision.

With TF and Keras, mixed precision is configured with the following settings:

policy = keras.mixed_precision.Policy('mixed_float16')
keras.mixed_precision.set_global_policy(policy)
However, the existing TFDebertaModel and TFDebertaV2Model throws TypeError with this mixed precision setting.
With mixed precision, TF and Keras requires to use Layer.dtype for model or layer's weights and Layer.compute_dtype for internal tensor computation. But the current TFDebertaModel and TFDebertaV2Model codes do not seem to reflect this requirement and definitely assume the dtype would be tf.float32.

I searched and corrected some error-prone code snippets in modeling_tf_deberta.py and modeling_tf_deberta_v2.py.
This correction worked correctly with mixed precision in my local machine.

This PR fixes [#31989](https://github.com/huggingface/transformers/issues/31989)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [V] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [V] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?


